### PR TITLE
feat: Move all files for packing into `out` subdirectory

### DIFF
--- a/.github/workflows/build-deploy-and-tag-ecr-image.yml
+++ b/.github/workflows/build-deploy-and-tag-ecr-image.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'DTE-848-pre-pack-lambda-change'
   workflow_dispatch:
 jobs:
   ecr-deploy:

--- a/.github/workflows/build-deploy-and-tag-ecr-image.yml
+++ b/.github/workflows/build-deploy-and-tag-ecr-image.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'DTE-848-pre-pack-lambda-change'
   workflow_dispatch:
 jobs:
   ecr-deploy:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # da-tre-fn-court-document-pre-packer
 
-A lambda to build a metadata json file to be included in the final package, and to place this alongside all other files in IO directory for packaging into a subfolder named according to reference.
+A lambda to build a metadata json file to be included in the final package, and to place this alongside all other desired output files in IO directory for packaging into a subfolder named according to reference.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-# da-tre-fn-template
-A template repository with a skeleton scala handlers for a range of event types, a workflow for pushing images to ECR, and some simple examples of message parsing and testing.
+# da-tre-fn-court-document-pre-packer
 
-The template lambda is generically typed to demonstrate handling of a selection of common events, but both event and return type can be configured as required.
-
-## Testing
-
-Sample feature and unit test for noop logging handlers are provided for each event type.
-
-## Workflow
-
-An on push workflow is provided which versions, tags, and pushes to ECR an image built from the latest code.
-
-## Message parsing
-Example parsing utils are supplied for `CourtDocumentPackage` : the precise circe codecs required will need adapting depending on types nested in parameters of the TRE message in question.
+A lambda to build a metadata json file to be included in the final package, and to place this alongside all other files in IO directory for packaging into a subfolder named according to reference.

--- a/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
@@ -40,7 +40,7 @@ class LambdaHandler extends RequestHandler[SNSEvent, String] {
       Some(s3Utils.getFileContent(s3Bucket, s"$s3FolderName/metadata.json"))
     else None
     val metadataFileContent = buildMetadataFileContents(reference, fileNames, metadataFileName, parserMetadata)
-    val toPackDirectory = s"${s3FolderName}out"
+    val toPackDirectory = s"$s3FolderName/out"
     s3Utils.saveStringToFile(metadataFileContent, s3Bucket, s"$toPackDirectory/$reference/$metadataFileName")
     val filesToPack = Seq(
       "bag-info.txt",

--- a/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
@@ -7,7 +7,6 @@ import software.amazon.awssdk.services.s3.S3Client
 import uk.gov.nationalarchives.tre.MessageParsingUtils._
 import uk.gov.nationalarchives.tre.MetadataConstructionUtils._
 import uk.gov.nationalarchives.tre.messages.courtdocument.parse.CourtDocumentParse
-import uk.gov.nationalarchives.tre.messages.courtdocumentpackage.prepare.CourtDocumentPackagePrepare
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -20,8 +19,8 @@ class LambdaHandler extends RequestHandler[SNSEvent, String] {
         context.getLogger.log(s"Received SNS message: ${snsRecord.getSNS.getMessage}\n")
         val courtDocumentParseMessage = parseCourtDocumentParseMessage(snsRecord.getSNS.getMessage)
         context.getLogger.log(s"Successfully parsed incoming message as CourtDocumentParse\n")
-        buildTREMetadataFileAndUploadToS3(courtDocumentParseMessage, s3Utils)
-        context.getLogger.log(s"Successfully uploaded TRE metadata file to S3\n")
+        populateOutDirectory(courtDocumentParseMessage, s3Utils)
+        context.getLogger.log(s"Successfully populated out directory\n")
         val prepareMessage = courtDocumentPackagePrepareJsonString(courtDocumentParseMessage)
         context.getLogger.log(s"Returning court document prepare message: $prepareMessage\n")
         prepareMessage
@@ -29,7 +28,7 @@ class LambdaHandler extends RequestHandler[SNSEvent, String] {
     }
   }
 
-  private def buildTREMetadataFileAndUploadToS3(
+  private def populateOutDirectory(
     courtDocumentParseMessage: CourtDocumentParse,
     s3Utils: S3Utils
   ): Unit = {

--- a/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
@@ -41,7 +41,7 @@ class LambdaHandler extends RequestHandler[SNSEvent, String] {
     else None
     val metadataFileContent = buildMetadataFileContents(reference, fileNames, metadataFileName, parserMetadata)
     val toPackDirectory = s"$s3FolderName/out"
-    s3Utils.saveStringToFile(metadataFileContent, s3Bucket, s"$toPackDirectory/$reference/$metadataFileName")
+    s3Utils.saveStringToFile(metadataFileContent, s3Bucket, s"$toPackDirectory/$metadataFileName")
     val filesToPack = Seq(
       "bag-info.txt",
       "manifest-sha256.txt",
@@ -54,7 +54,7 @@ class LambdaHandler extends RequestHandler[SNSEvent, String] {
         fromBucket = s3Bucket,
         toBucket = s3Bucket,
         fromKey = s"$s3FolderName/$fileName",
-        toKey = s"$toPackDirectory/$reference/$fileName"
+        toKey = s"$toPackDirectory/$fileName"
       )
     }
   }

--- a/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
@@ -40,7 +40,7 @@ class LambdaHandler extends RequestHandler[SNSEvent, String] {
       Some(s3Utils.getFileContent(s3Bucket, s"$s3FolderName/metadata.json"))
     else None
     val metadataFileContent = buildMetadataFileContents(reference, fileNames, metadataFileName, parserMetadata)
-    val toPackDirectory = s"$s3FolderName/out/"
+    val toPackDirectory = s"${s3FolderName}out"
     s3Utils.saveStringToFile(metadataFileContent, s3Bucket, s"$toPackDirectory/$reference/$metadataFileName")
     val filesToPack = Seq(
       "bag-info.txt",

--- a/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
@@ -37,6 +37,6 @@ object MessageParsingUtils {
         executionId = uuid,
         parentExecutionId = Some(courtDocumentParseMessage.properties.executionId)
       ),
-      parameters = courtDocumentParseMessage.parameters.copy(s3FolderName = s"${courtDocumentParseMessage.parameters.s3FolderName}/out")
+      parameters = courtDocumentParseMessage.parameters.copy(s3FolderName = s"${courtDocumentParseMessage.parameters.s3FolderName}out")
     ).asJson.toString
 }

--- a/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
@@ -27,8 +27,7 @@ object MessageParsingUtils {
     courtDocumentParseMessage: CourtDocumentParse,
     uuid:  String = UUID.randomUUID().toString,
     timestamp: String = Instant.now().toString
-  ): String = {
-    import courtDocumentParseMessage.parameters._
+  ): String =
     CourtDocumentPackagePrepare(
       properties = Properties(
         messageType = "uk.gov.nationalarchives.tre.messages.courtdocumentpackage.prepare.CourtDocumentPackagePrepare",
@@ -38,7 +37,6 @@ object MessageParsingUtils {
         executionId = uuid,
         parentExecutionId = Some(courtDocumentParseMessage.properties.executionId)
       ),
-      parameters = courtDocumentParseMessage.parameters.copy(s3FolderName = s"$s3FolderName/$reference/")
+      parameters = courtDocumentParseMessage.parameters.copy(s3FolderName = s"${courtDocumentParseMessage.parameters.s3FolderName}/out")
     ).asJson.toString
-  }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
@@ -27,7 +27,8 @@ object MessageParsingUtils {
     courtDocumentParseMessage: CourtDocumentParse,
     uuid:  String = UUID.randomUUID().toString,
     timestamp: String = Instant.now().toString
-  ): String =
+  ): String = {
+    import courtDocumentParseMessage.parameters._
     CourtDocumentPackagePrepare(
       properties = Properties(
         messageType = "uk.gov.nationalarchives.tre.messages.courtdocumentpackage.prepare.CourtDocumentPackagePrepare",
@@ -37,6 +38,7 @@ object MessageParsingUtils {
         executionId = uuid,
         parentExecutionId = Some(courtDocumentParseMessage.properties.executionId)
       ),
-      parameters = courtDocumentParseMessage.parameters.copy(s3FolderName = s"${courtDocumentParseMessage.parameters.s3FolderName}/")
+      parameters = courtDocumentParseMessage.parameters.copy(s3FolderName = s"$s3FolderName/$reference/")
     ).asJson.toString
+  }
 }

--- a/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
@@ -37,6 +37,6 @@ object MessageParsingUtils {
         executionId = uuid,
         parentExecutionId = Some(courtDocumentParseMessage.properties.executionId)
       ),
-      parameters = courtDocumentParseMessage.parameters.copy(s3FolderName = s"${courtDocumentParseMessage.parameters.s3FolderName}out")
+      parameters = courtDocumentParseMessage.parameters.copy(s3FolderName = s"${courtDocumentParseMessage.parameters.s3FolderName}/out")
     ).asJson.toString
 }

--- a/src/main/scala/uk/gov/nationalarchives/tre/S3Utils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/S3Utils.scala
@@ -3,7 +3,7 @@ package uk.gov.nationalarchives.tre
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{GetObjectRequest, ListObjectsV2Request, ListObjectsV2Response, PutObjectRequest}
+import software.amazon.awssdk.services.s3.model.{CopyObjectRequest, CopyObjectResponse, DeleteObjectRequest, DeleteObjectResponse, GetObjectRequest, ListObjectsV2Request, ListObjectsV2Response, PutObjectRequest}
 
 import java.io.{BufferedReader, InputStreamReader}
 import scala.jdk.CollectionConverters._
@@ -32,6 +32,24 @@ class S3Utils(s3Client: S3Client) {
     val content = Iterator.continually(bufferedReader.readLine()).takeWhile(_ != null).mkString("\n")
     bufferedReader.close()
     content
+  }
+
+  def copyFile(fromBucket: String, toBucket: String, fromKey: String, toKey: String): CopyObjectResponse = {
+    val copyObjectRequest: CopyObjectRequest = CopyObjectRequest.builder()
+      .sourceBucket(fromBucket)
+      .sourceKey(fromKey)
+      .destinationBucket(toBucket)
+      .destinationKey(toKey)
+      .build()
+    s3Client.copyObject(copyObjectRequest)
+  }
+
+  def deleteFile(bucket: String, key: String): DeleteObjectResponse = {
+    val deleteObjectRequest: DeleteObjectRequest = DeleteObjectRequest.builder()
+      .bucket(bucket)
+      .key(key)
+      .build()
+    s3Client.deleteObject(deleteObjectRequest)
   }
 
   def saveStringToFile(content: String, bucketName: String, key: String): Unit = {

--- a/src/main/scala/uk/gov/nationalarchives/tre/S3Utils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/S3Utils.scala
@@ -44,14 +44,6 @@ class S3Utils(s3Client: S3Client) {
     s3Client.copyObject(copyObjectRequest)
   }
 
-  def deleteFile(bucket: String, key: String): DeleteObjectResponse = {
-    val deleteObjectRequest: DeleteObjectRequest = DeleteObjectRequest.builder()
-      .bucket(bucket)
-      .key(key)
-      .build()
-    s3Client.deleteObject(deleteObjectRequest)
-  }
-
   def saveStringToFile(content: String, bucketName: String, key: String): Unit = {
     val putObjectRequest = PutObjectRequest.builder()
       .bucket(bucketName)

--- a/src/test/scala/uk.gov.nationalarchives.tre/MessageParsingUtilsSpec.scala
+++ b/src/test/scala/uk.gov.nationalarchives.tre/MessageParsingUtilsSpec.scala
@@ -56,7 +56,7 @@ class MessageParsingUtilsSpec extends AnyFlatSpec with MockitoSugar {
     parseCourtDocumentParseMessage(courtDocumentParseJsonString) shouldBe courtDocumentParse
   }
 
-  "courtDocumentPackagePrepareJsonString" should "produce a json string from a valid CourtDocumentPackagePrepare case class, adding a trailing slash to the s3FolderName for compatibility with python packer lambda" in {
+  "courtDocumentPackagePrepareJsonString" should "produce a json string from a valid CourtDocumentPackagePrepare case class, specifying the out directory for packing" in {
     val testUUID = UUID.randomUUID().toString
     val testTimestamp = Instant.now().toString
     val courtDocumentPackagePrepareJsonString =
@@ -71,7 +71,7 @@ class MessageParsingUtilsSpec extends AnyFlatSpec with MockitoSugar {
          |  },
          |  "parameters" : {
          |    "originator" : "TRE",
-         |    "s3FolderName" : "TRE-TEST/execution-id/",
+         |    "s3FolderName" : "TRE-TEST/execution-id/out",
          |    "s3Bucket" : "test-tre-common-data",
          |    "reference" : "TRE-TEST",
          |    "status" : "COURT_DOCUMENT_PARSE_NO_ERRORS"


### PR DESCRIPTION
This change to the pre packer works off a list of the output files we would like to pack, as well as the original input file (placed in a `data` file within the working directory either by the [court document parse step function](https://github.com/nationalarchives/da-tre-tf-module-parse-court-document/pull/25) or at the bag unpacking stage in the case of requests from TDR.

## Test Plan
Pushed updated version to ECR and updated pte to use it. Used system testing repo to test end to end for FCL and verified pack appearance as expected.