### PR TITLE
feat: Strip out leading directory in metadata filenames

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tre/MetadataConstructionUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/MetadataConstructionUtils.scala
@@ -29,5 +29,5 @@ object MetadataConstructionUtils {
   }
 
   def getFileNameWithSuffix(suffix: String): Seq[String] => JsValue = fileNames =>
-    fileNames.find(_.endsWith(suffix)).map(JsString).getOrElse(JsNull)
+    fileNames.flatMap(_.split('/').lastOption).find(_.endsWith(suffix)).map(JsString).getOrElse(JsNull)
 }

--- a/src/test/scala/uk.gov.nationalarchives.tre/MetadataConstructionUtilsSpec.scala
+++ b/src/test/scala/uk.gov.nationalarchives.tre/MetadataConstructionUtilsSpec.scala
@@ -72,6 +72,13 @@ class MetadataConstructionUtilsSpec extends AnyFlatSpec {
     expectedFileName shouldBe actualFileName
   }
 
+  it should "strip out any leading directory and return the filename only" in {
+    val expectedDocxFileName = JsString("eat_2022_1.docx")
+    val actualDocxFileName = MetadataConstructionUtils
+      .getFileNameWithSuffix(".docx")(Seq("data/eat_2022_1.docx", "FCL-151.xml", "metadata.json", "parser.log"))
+    expectedDocxFileName shouldBe actualDocxFileName
+  }
+
   it should "return null if no files with the given suffix are present" in {
     val expectedFileName = JsNull
     val actualFileName = MetadataConstructionUtils.getFileNameWithSuffix(".docx")(Seq("parser.log"))


### PR DESCRIPTION
The s3 library used by the packer downstream strips out all leading directories in any case. This is causing a mismatch with the file location specified in the metadata file, so in anticipation of this we strip any directory in the metadata file here.

As [requested in FCL testing](https://tna-digital.slack.com/archives/C02VDE9US4R/p1692799340957949?thread_ts=1692099675.857789&cid=C02VDE9US4R).

## Test Plan
UT; PTE