### PR TITLE
feat: Add images to pre packer

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
@@ -59,7 +59,7 @@ class LambdaHandler extends RequestHandler[SNSEvent, String] {
       "manifest-sha256.txt",
       s"$reference.xml",
       "parser.log"
-    ) ++ parserOutputs.value.getOrElse("images", Json.arr()).as[Seq[String]]
+    ) ++ parserOutputs.value.get("images").map(_.as[Seq[String]]).getOrElse(Seq.empty)
 
     val isInputFile: String => Boolean = s => s.startsWith("data/") && s.endsWith("docx")
     fileNames.filter(n => filesToPack.contains(n) || isInputFile(n)).foreach { fileName =>

--- a/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
@@ -29,6 +29,11 @@ class LambdaHandler extends RequestHandler[SNSEvent, String] {
     }
   }
 
+  /**
+   * Builds a TRE specific metadata file and places it into an "out" directory alongside other key files produced by
+   * the parser
+   * @return The directory into which files have been placed ready for packing
+   */
   private def populateOutDirectory(
     courtDocumentParseMessage: CourtDocumentParse,
     s3Utils: S3Utils

--- a/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/LambdaHandler.scala
@@ -43,7 +43,7 @@ class LambdaHandler extends RequestHandler[SNSEvent, String] {
     val fileNames = s3Utils.getFileNames(s3Bucket, s3FolderName)
 
     val fileContentFromS3: String => Option[String] = fileName => if (fileNames.contains(fileName))
-      Some(s3Utils.getFileContent(s3Bucket, s"$s3FolderName/metadata.json"))
+      Some(s3Utils.getFileContent(s3Bucket, s"$s3FolderName/$fileName"))
     else None
 
     val parserMetadata = asJson(fileContentFromS3("metadata.json"))

--- a/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
@@ -26,7 +26,8 @@ object MessageParsingUtils {
   def courtDocumentPackagePrepareJsonString(
     courtDocumentParseMessage: CourtDocumentParse,
     uuid:  String = UUID.randomUUID().toString,
-    timestamp: String = Instant.now().toString
+    timestamp: String = Instant.now().toString,
+    outDirectory: String
   ): String =
     CourtDocumentPackagePrepare(
       properties = Properties(
@@ -37,6 +38,6 @@ object MessageParsingUtils {
         executionId = uuid,
         parentExecutionId = Some(courtDocumentParseMessage.properties.executionId)
       ),
-      parameters = courtDocumentParseMessage.parameters.copy(s3FolderName = s"${courtDocumentParseMessage.parameters.s3FolderName}/out")
+      parameters = courtDocumentParseMessage.parameters.copy(s3FolderName = outDirectory)
     ).asJson.toString
 }

--- a/src/test/scala/uk.gov.nationalarchives.tre/MessageParsingUtilsSpec.scala
+++ b/src/test/scala/uk.gov.nationalarchives.tre/MessageParsingUtilsSpec.scala
@@ -77,6 +77,6 @@ class MessageParsingUtilsSpec extends AnyFlatSpec with MockitoSugar {
          |    "status" : "COURT_DOCUMENT_PARSE_NO_ERRORS"
          |  }
          |}""".stripMargin
-    MessageParsingUtils.courtDocumentPackagePrepareJsonString(courtDocumentParse, testUUID,  testTimestamp) shouldBe courtDocumentPackagePrepareJsonString
+    MessageParsingUtils.courtDocumentPackagePrepareJsonString(courtDocumentParse, testUUID,  testTimestamp, outDirectory = "TRE-TEST/execution-id/out") shouldBe courtDocumentPackagePrepareJsonString
   }
 }


### PR DESCRIPTION
For parity with v1, add images to the packing output, as well as referencing them in the metadata file.

Also a little change here to return the pack out directory from the function that populates it, so that then can be used in building the `CourtDocumentPackagePrepare` message, as opposed to hard coding it in two places.

## Test plan
Deploy new pre-packer image to PTE, run system tests for input docs with 0, 1 and multiple images and verify output as expected.